### PR TITLE
Update support page and footer with new Discord invite link

### DIFF
--- a/components/layout/Footer.jsx
+++ b/components/layout/Footer.jsx
@@ -154,6 +154,9 @@ export function Footer({ ...props }) {
           <NextLink href="https://twitter.com/SmartInvoiceXYZ" target="_blank" passHref>
             <Link target="_blank">Twitter</Link>
           </NextLink>
+          <NextLink href="https://discord.gg/Rws3gEu8W7" target="_blank" passHref>
+            <Link target="_blank">Discord</Link>
+          </NextLink>
         </Flex>
       </Flex>
     </Flex>

--- a/docs-v2/misc/get-support.md
+++ b/docs-v2/misc/get-support.md
@@ -4,8 +4,6 @@ title: Get Support
 
 Still can’t figure Smart Invoice out? No worries, our team is happy to help you directly.
 
-We’re available in the RaidGuild DAO Discord (https://discord.gg/M2QaDPgKFR).
+We’re available in the [Smart Invoice Discord](https://discord.gg/Rws3gEu8W7).
 
-Once inside of the Discord, navigate to the “Town Square” area and leave a message for us inside of the “product-support” channel.
-
-**Note: Smart Invoice is a product of RaidGuild DAO, so that's why you'll be messaging us in that Discord.*
+Once in there, leave a message for us in the “support” channel.


### PR DESCRIPTION
Made the following changes:
- Updated text on `get-support` page to reference Smart Invoice discord server and its support channel. Discord link on that page now invites to the Smart Invoice Discord rather than Raid Guild.
- Added Discord and its invite link to the footer.